### PR TITLE
Bump version to 0.3.2.av

### DIFF
--- a/lib/jsonify-rails/version.rb
+++ b/lib/jsonify-rails/version.rb
@@ -1,4 +1,4 @@
 module JsonifyRails
-  VERSION = "0.3.2"
+  VERSION = "0.3.2.av"
 end
   


### PR DESCRIPTION
Bump version to 0.3.2.av

- av here stands for app volumes added so that it does not interfere with the other versions if released